### PR TITLE
Use existing number of students form for new cross report

### DIFF
--- a/controllers/reports/numberOfStudentsCross.js
+++ b/controllers/reports/numberOfStudentsCross.js
@@ -14,18 +14,27 @@ function getBarWidth(barCount) {
 module.exports = context => {
   const { reportUtils } = context;
 
+  const validCriteria = [
+    'postSchoolOutcome',
+    'skillTraining',
+    'supportNeed',
+    'riskLevel',
+    'disability',
+    'iepRole',
+    'activityGroupTypes',
+  ];
+
   return async function createNumberOfStudentsCrossReport(options) {
     const {
       startYearId,
       startTermId,
-      byPostSchoolOutcome,
-      byRiskLevel,
-      bySkillTraining,
-      bySupportNeed,
-      byIEPRole,
-      byDisability,
-      byActivityGroupTypes,
+      criteria1,
+      criteria2,
     } = options;
+
+    if(!criteria1 || !criteria2) throw new Error('You must select 2 categories to graph');
+    if(!validCriteria.includes(criteria1)) throw new Error(`Invalid criteria "${criteria1}"`);
+    if(!validCriteria.includes(criteria2)) throw new Error(`Invalid criteria "${criteria2}"`);
 
     const reportData = await reportUtils.getSingleTermReportData({startYearId, startTermId});
     const {
@@ -38,17 +47,6 @@ module.exports = context => {
       activityTypeGroups,
     } = reportData;
 
-    const [ criteria1, criteria2 ] = [
-      byPostSchoolOutcome && 'postSchoolOutcome',
-      bySkillTraining && 'skillTraining',
-      bySupportNeed && 'supportNeed',
-      byRiskLevel && 'riskLevel',
-      byDisability && 'disability',
-      byIEPRole && 'iepRole',
-      byActivityGroupTypes && 'activityGroupTypes',
-    ].filter(v => !!v);
-    
-    if(!criteria1 || !criteria2) throw new Error('You must select 2 categories to graph');
     const students = criteria1 === 'postSchoolOutcome' || criteria2 === 'postSchoolOutcome'
       ? postSchoolStudents
       : inSchoolStudents;
@@ -97,15 +95,19 @@ const criteriaLabels = {
   postSchoolOutcome() {
     return [
       {
-        key: 'postSecondaryEducation',
+        key: 'Post-Secondary Education',
         label: 'Post-Secondary Education',
       },
       {
-        key: 'postSchoolEmployment',
+        key: 'Post-School Employment',
         label: 'Post-School Employment',
       },
       {
-        key: 'both',
+        key: 'Other',
+        label: 'Other',
+      },
+      {
+        key: 'Both',
         label: 'Both',
       },
     ];

--- a/routes/reports.router.js
+++ b/routes/reports.router.js
@@ -59,24 +59,18 @@ module.exports = context => {
       const {
         startYearId,
         startTermId,
-        byPostSchoolOutcome,
-        byRiskLevel,
-        bySkillTraining,
-        bySupportNeed,
-        byIEPRole,
-        byDisability,
-        byActivityGroupTypes,
+        primaryCriteria,
       } = ctx.request.query;
       const options = {
         startYearId: +startYearId,
         startTermId: +startTermId,
-        byPostSchoolOutcome: byPostSchoolOutcome === 'true',
-        byRiskLevel: byRiskLevel === 'true',
-        bySkillTraining: bySkillTraining === 'true',
-        bySupportNeed: bySupportNeed === 'true',
-        byIEPRole: byIEPRole === 'true',
-        byDisability: byDisability === 'true',
-        byActivityGroupTypes: byActivityGroupTypes === 'true',
+        byPostSchoolOutcome: primaryCriteria === 'postSchoolOutcome',
+        byRiskLevel: primaryCriteria === 'riskLevel',
+        bySkillTraining: primaryCriteria === 'skillTraining',
+        bySupportNeed: primaryCriteria === 'supportNeed',
+        byIEPRole: primaryCriteria === 'iepRole',
+        byDisability: primaryCriteria === 'disability',
+        byActivityGroupTypes: primaryCriteria === 'activityGroupTypes',
       };
       const data = await controllers.reportController.runReport(reportName, options);
       const html = template(data);
@@ -93,26 +87,20 @@ module.exports = context => {
         startTermId,
         endYearId,
         endTermId,
-        byPostSchoolOutcome,
-        byRiskLevel,
-        bySkillTraining,
-        bySupportNeed,
-        byIEPRole,
-        byDisability,
-        byActivityGroupTypes,
+        primaryCriteria,
       } = ctx.request.query;
       const options = {
         startYearId: +startYearId,
         startTermId: +startTermId,
         endYearId: +endYearId,
         endTermId: +endTermId,
-        byPostSchoolOutcome: byPostSchoolOutcome === 'true',
-        byRiskLevel: byRiskLevel === 'true',
-        bySkillTraining: bySkillTraining === 'true',
-        bySupportNeed: bySupportNeed === 'true',
-        byIEPRole: byIEPRole === 'true',
-        byDisability: byDisability === 'true',
-        byActivityGroupTypes: byActivityGroupTypes === 'true',
+        byPostSchoolOutcome: primaryCriteria === 'postSchoolOutcome',
+        byRiskLevel: primaryCriteria === 'riskLevel',
+        bySkillTraining: primaryCriteria === 'skillTraining',
+        bySupportNeed: primaryCriteria === 'supportNeed',
+        byIEPRole: primaryCriteria === 'iepRole',
+        byDisability: primaryCriteria === 'disability',
+        byActivityGroupTypes: primaryCriteria === 'activityGroupTypes',
       };
       const data = await controllers.reportController.runReport(reportName, options);
       const html = template(data);
@@ -127,24 +115,14 @@ module.exports = context => {
       const {
         startYearId,
         startTermId,
-        byPostSchoolOutcome,
-        byRiskLevel,
-        bySkillTraining,
-        bySupportNeed,
-        byIEPRole,
-        byDisability,
-        byActivityGroupTypes,
+        primaryCriteria,
+        secondaryCriteria,
       } = ctx.request.query;
       const options = {
         startYearId: +startYearId,
         startTermId: +startTermId,
-        byPostSchoolOutcome: byPostSchoolOutcome === 'true',
-        byRiskLevel: byRiskLevel === 'true',
-        bySkillTraining: bySkillTraining === 'true',
-        bySupportNeed: bySupportNeed === 'true',
-        byIEPRole: byIEPRole === 'true',
-        byDisability: byDisability === 'true',
-        byActivityGroupTypes: byActivityGroupTypes === 'true',
+        criteria1: primaryCriteria,
+        criteria2: secondaryCriteria,
       };
       const data = await controllers.reportController.runReport(reportName, options);
       const html = template(data);

--- a/tests/reports.test.js
+++ b/tests/reports.test.js
@@ -876,19 +876,6 @@ describe('reports', () => {
     expect(result.activities.length).toEqual(activityTypeGroups.length);
   });
 
-  rapidTest('Number of students standard report should be able to be run with all sub-reports enabled', async rapid => {
-    const options = await getLongitudinalReportOptions(rapid, {
-      byActivityGroupTypes: true,
-      byPostSchoolOutcome: true,
-      bySkillTraining: true,
-      bySupportNeed: true,
-      byIEPRole: true,
-      byRiskLevel: true,
-      byDisability: true,
-    });
-    await rapid.controllers.reportController.runReport('numberOfStudentsStandard', options);
-  });
-
   rapidTest('Number of students longitudinal report should run successfully', async rapid => {
     const options = await getLongitudinalReportOptions(rapid);
     await rapid.controllers.reportController.runReport('numberOfStudentsLongitudinal', options);


### PR DESCRIPTION
This mostly just adjust the number of students routes to use a single criteria input instead of a bunch of flags (since the user can no longer run the report with all the criteria selected).

Also:
Fixed a bug in the cross report when post school outcome criteria is selected.
Removed test that checks if the number of students report can be run with all criteria (no longer possible).