### PR TITLE
Fix "internal server error" error messages

### DIFF
--- a/controllers/Activity.controller.js
+++ b/controllers/Activity.controller.js
@@ -1,5 +1,6 @@
 module.exports = context => {
   const removeNullValues = require('../utils/removeNullValues');
+  const validationError = require('../utils/validationError');
   const { models } = context;
   const { Activity, ActivityTypeGroup, ActivityEvent } = models;
 
@@ -26,11 +27,7 @@ module.exports = context => {
 
     async createActivity(fields) {
       const { events, ...rest } = fields;
-      if(!events || !events.length) {
-        const error = new Error('You must add at least one event.');
-        error.status = 400;
-        throw error;
-      }
+      if(!events || !events.length) throw validationError('You must add at least one event.')
       const activity = await Activity.query().insert(rest).returning('*').eager('[activityType]');
       activity.events = await this.createActivityEvents(activity.id, events);
       return activity;
@@ -39,7 +36,7 @@ module.exports = context => {
     async editActivity(activityId, fields) {
       const { events, ...rest } = fields;
       
-      if(!events || !events.length) throw new Error('You must add at least one event.');
+      if(!events || !events.length) throw validationError('You must add at least one event.');
       await this.deleteActivityEvents(activityId);
       await this.createActivityEvents(activityId, events);
 

--- a/controllers/Report.controller.js
+++ b/controllers/Report.controller.js
@@ -1,12 +1,13 @@
 module.exports = context => {
   context.reportUtils = require('../utils/reportUtils')(context);
+  const validationError = require('../utils/validationError');
   const reports = require('./reports')(context);
   const reportNames = Object.keys(reports);
 
   class ReportController {
     runReport(name, options) {
       console.log(`Running report ${name}`);
-      if(!reportNames.includes(name)) throw new Error(`Invalid report name "${name}"`);
+      if(!reportNames.includes(name)) throw validationError(`Invalid report name "${name}"`);
       return reports[name](options);
     }
   }

--- a/controllers/SchoolYear.controller.js
+++ b/controllers/SchoolYear.controller.js
@@ -1,5 +1,6 @@
 module.exports = context => {
   const { flatten } = require('lodash');
+  const validationError = require('../utils/validationError');
   const { models } = context;
   const { SchoolYear, StudentTermInfo } = models;
 
@@ -38,8 +39,8 @@ module.exports = context => {
       terms,
       students,
     }) {
-      if(!termTypeCounts.hasOwnProperty(termType)) throw new Error(`Invalid term type "${termType}".`);
-      if(termTypeCounts[termType] !== terms.length) throw new Error(`Invalid number of terms. Term type "${termType}" requires ${termTypeCounts[termType]} term${termTypeCounts[termType] !== 1 ? 's' : ''} (${terms.length} provided).`);
+      if(!termTypeCounts.hasOwnProperty(termType)) throw validationError(`Invalid term type "${termType}".`);
+      if(termTypeCounts[termType] !== terms.length) throw validationError(`Invalid number of terms. Term type "${termType}" requires ${termTypeCounts[termType]} term${termTypeCounts[termType] !== 1 ? 's' : ''} (${terms.length} provided).`);
       
       // Create school year and terms
       const schoolYear = await SchoolYear.query().insertGraphAndFetch({

--- a/controllers/Student.controller.js
+++ b/controllers/Student.controller.js
@@ -1,5 +1,6 @@
 module.exports = context => {
   const removeNullValues = require('../utils/removeNullValues');
+  const validationError = require('../utils/validationError');
   const Json2csvParser = require('json2csv').Parser;
   const { models } = context;
   const { Student, SchoolYear, StudentDisability, StudentTermInfo, Term } = models;
@@ -47,7 +48,7 @@ module.exports = context => {
     }) {
       const existingStudent = await Student.query().where('studentId', studentId).first();
       if(existingStudent) {
-        throw new Error(`A student already exists with the id "${studentId}"`);
+        throw validationError(`A student already exists with the id "${studentId}"`);
       }
       const student = await Student.query().insert({
         studentId,
@@ -97,7 +98,7 @@ module.exports = context => {
     }) {
       const existingStudent = studentId && await Student.query().where('studentId', studentId).first();
       if(existingStudent && existingStudent.id !== id) {
-        throw new Error(`A student already exists with the id "${studentId}"`);
+        throw validationError(`A student already exists with the id "${studentId}"`);
       }
 
       const fields = removeNullValues({

--- a/controllers/reports/numberOfStudentsCross.js
+++ b/controllers/reports/numberOfStudentsCross.js
@@ -1,7 +1,9 @@
 const groupBy = require('lodash/groupBy');
 const map = require('lodash/map');
 const uniq = require('lodash/uniq');
+const validationError = require('../../utils/validationError');
 const enums = require('../../enums');
+
 
 function getBarWidth(barCount) {
   if(barCount <= 10) return 30;
@@ -34,9 +36,9 @@ module.exports = context => {
       criteria2,
     } = options;
 
-    if(!criteria1 || !criteria2) throw new Error('You must select 2 categories to graph');
-    if(!validCriteria.includes(criteria1)) throw new Error(`Invalid criteria "${criteria1}"`);
-    if(!validCriteria.includes(criteria2)) throw new Error(`Invalid criteria "${criteria2}"`);
+    if(!criteria1 || !criteria2) throw validationError('You must select 2 categories to graph');
+    if(!validCriteria.includes(criteria1)) throw validationError(`Invalid criteria "${criteria1}"`);
+    if(!validCriteria.includes(criteria2)) throw validationError(`Invalid criteria "${criteria2}"`);
 
     const reportData = await reportUtils.getSingleTermReportData({startYearId, startTermId});
     const {
@@ -382,12 +384,12 @@ const criteriaGroupers = {
 };
 
 function getCriteriaLabels(criteria, reportData) {
-  if(!criteriaLabels.hasOwnProperty(criteria)) throw new Error(`Invalid criteria: "${criteria}"`);
+  if(!criteriaLabels.hasOwnProperty(criteria)) throw validationError(`Invalid criteria: "${criteria}"`);
   return criteriaLabels[criteria](reportData);
 }
 
 function groupStudentsByCriteria(students, criteria, reportData) {
-  if(!criteriaGroupers.hasOwnProperty(criteria)) throw new Error(`Invalid criteria: "${criteria}"`);
+  if(!criteriaGroupers.hasOwnProperty(criteria)) throw validationError(`Invalid criteria: "${criteria}"`);
   return criteriaGroupers[criteria](students, reportData);
 }
 

--- a/models/User.model.js
+++ b/models/User.model.js
@@ -1,4 +1,5 @@
 module.exports = context => {
+  const validationError = require('../utils/validationError');
   const { Model, models, decorators } = context;
 
   class User extends Model {
@@ -27,7 +28,7 @@ module.exports = context => {
 
     async validateEmail(email) {
       if(email && (await this.isEmailInUse(email))) {
-        throw new Error('A user with that email already exists.');
+        throw validationError('A user with that email already exists.');
       }
     }
 

--- a/utils/reportUtils.js
+++ b/utils/reportUtils.js
@@ -1,6 +1,7 @@
 module.exports = context => {
   const { models, controllers } = context;
   const { enums } = require('tgb-shared');
+  const validationError = require('./validationError');
   const {
     property,
     flatMap,
@@ -51,10 +52,10 @@ module.exports = context => {
       getActivityTypeGroups(),
     ]);
 
-    if(!startYear) throw new Error('Invalid start year.');
-    if(!startTerm) throw new Error('Invalid start term.');
-    if(!endYear) throw new Error('Invalid end year.');
-    if(!endTerm) throw new Error('Invalid end term.');
+    if(!startYear) throw validationError('Invalid start year.');
+    if(!startTerm) throw validationError('Invalid start term.');
+    if(!endYear) throw validationError('Invalid end year.');
+    if(!endTerm) throw validationError('Invalid end term.');
 
     // Make sure startYear is before endYear and startTerm is before endTerm
     if(startYear.year > endYear.year) [startYear, endYear] = [endYear, startYear];

--- a/utils/validationError.js
+++ b/utils/validationError.js
@@ -1,0 +1,6 @@
+
+module.exports = function validationError(message, status=400) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};


### PR DESCRIPTION
Add validation error util and switch all validation errors to use new util function.

Currently Rapid checks uncaught errors for a `status` field. In production, if no `status` is found, "Internal server error." is returned to avoid leaking data through unexpected errors. I'm going to change it so this is also the behavior in development so these bugs get caught sooner.