### PR TITLE
Updated the styles of the student over time report to be more consistent

### DIFF
--- a/reportTemplates/components/ActivityOverTimeTable.js
+++ b/reportTemplates/components/ActivityOverTimeTable.js
@@ -1,0 +1,61 @@
+const React = require('react');
+
+const activityOverTimeTable = require('../styles/activityOverTimeTable');
+
+function displayValue(value, defaultValue = 'N/A') {
+  if (value == null) return defaultValue;
+  return value;
+}
+
+const TermsHeader = ({
+  title,
+  terms
+}) => React.createElement("div", {
+  className: "activity-over-time-table-row activity-over-time-table-header"
+}, React.createElement("div", {
+  className: "activity-over-time-table-title"
+}, title), React.createElement(React.Fragment, null, terms && terms.map((term, i) => React.createElement("div", {
+  className: "activity-over-time-table-header-label",
+  key: i
+}, React.createElement("div", null, term.name)))));
+
+const TermsRow = ({
+  entry,
+  height
+}) => {
+  const {
+    label,
+    values
+  } = entry;
+  return React.createElement("div", {
+    className: "activity-over-time-table-row activity-over-time-table-body",
+    style: {
+      height
+    }
+  }, React.createElement("div", {
+    className: "activity-over-time-table-label-container"
+  }, React.createElement("div", {
+    className: "activity-over-time-table-label"
+  }, label)), values.map((value, i) => React.createElement("div", {
+    className: "activity-over-time-table-value",
+    key: i
+  }, displayValue(value))));
+};
+
+module.exports = function ActivityOverTimeTable({
+  rows,
+  title,
+  rowHeight,
+  terms
+}) {
+  return React.createElement(React.Fragment, null, React.createElement("div", {
+    className: "activity-over-time-table"
+  }, React.createElement(TermsHeader, {
+    title: title,
+    terms: terms
+  }), rows.map((entry, i) => React.createElement(TermsRow, {
+    key: i,
+    entry: entry,
+    eight: rowHeight
+  }))), React.createElement("style", null, activityOverTimeTable));
+};

--- a/reportTemplates/studentActivitiesReport.js
+++ b/reportTemplates/studentActivitiesReport.js
@@ -1,5 +1,3 @@
-function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
-
 const React = require('react');
 
 const {
@@ -14,7 +12,7 @@ const StudentStatusBar = require('./components/StudentStatusBar');
 
 const studentRiskReportStyle = require('./styles/studentRiskReport');
 
-const Icons = require('./components/icons');
+const ActivityOverTimeTable = require('./components/ActivityOverTimeTable');
 
 class StudentActivitiesReport extends Component {
   render() {
@@ -29,6 +27,32 @@ class StudentActivitiesReport extends Component {
       students,
       activityTypeGroups
     } = this.props.data;
+    const iepRows = students.map(student => {
+      const {
+        iepRoles
+      } = student;
+      const values = iepRoles.map((role, i) => {
+        const attended = !!role ? 'YES' : ' ';
+        const roleDisplay = role || ' ';
+        return React.createElement("div", {
+          key: `student_role_${i}`
+        }, React.createElement("div", null, attended), React.createElement("div", null, roleDisplay));
+      });
+      return {
+        label: '',
+        values
+      };
+    });
+    const gradPlanRows = students.map(student => {
+      const {
+        graduationPlans
+      } = student;
+      const values = graduationPlans.map(graduationPlan => graduationPlan ? 'YES' : ' ');
+      return {
+        label: '',
+        values
+      };
+    });
     return React.createElement(React.Fragment, null, React.createElement(MultiTermReportTitle, {
       reportName: "Student Activities Report",
       schoolSettings: schoolSettings,
@@ -38,40 +62,35 @@ class StudentActivitiesReport extends Component {
       endTerm: endTerm
     }), React.createElement(StudentStatusBar, {
       student: studentInfo
-    }), React.createElement(IEPActivityTable, {
+    }), React.createElement(ActivityOverTimeTable, {
+      title: "ATTENDED IEP MEETING",
       terms: terms,
-      students: students
-    }), React.createElement(GraduationPlanActivitiesTable, {
+      rows: iepRows
+    }), React.createElement(ActivityOverTimeTable, {
+      title: "CAREER DEVELOPMENT / GRADUATION PLAN",
       terms: terms,
-      students: students
-    }), activityTypeGroups.map((group, i) => React.createElement(ActivityTable, {
-      key: group.id,
-      break: i === 1 || i === 3
-    }, React.createElement(ActivityTableHeader, {
-      title: group.name,
-      terms: terms
-    }), React.createElement("tbody", {
-      style: {
-        borderTop: '10px solid white'
-      }
-    }, group.activityTypes.map((type, i) => React.createElement("tr", {
-      key: type.id,
-      style: {
-        backgroundColor: i % 2 ? 'white' : '#F4F4F4'
-      }
-    }, React.createElement("td", {
-      style: {
-        textAlign: 'left',
-        fontSize: 10,
-        paddingLeft: 10
-      }
-    }, type.name), terms.map(term => React.createElement("td", {
-      key: term.id,
-      style: {
-        fontSize: 8,
-        borderLeft: '1px solid #D43425'
-      }
-    }, term.student ? term.student.activities.filter(a => a.activityTypeId === type.id).length : 'N/A'))))))), students.map((student, i) => {
+      rows: gradPlanRows
+    }), activityTypeGroups.map((group, i) => {
+      const activityGroupRows = group.activityTypes.map(type => {
+        const values = terms.map(term => term.student ? term.student.activities.filter(a => a.activityTypeId === type.id).length : 'N/A');
+        const label = type.name;
+        return {
+          label,
+          values
+        };
+      });
+      return React.createElement(React.Fragment, {
+        key: group.id
+      }, [0, 1, 3].includes(i) && React.createElement("div", {
+        style: {
+          pageBreakBefore: 'always'
+        }
+      }), React.createElement(ActivityOverTimeTable, {
+        title: group.name,
+        terms: terms,
+        rows: activityGroupRows
+      }));
+    }), students.map((student, i) => {
       const {
         riskFactors,
         studentNeeds,
@@ -96,127 +115,12 @@ class StudentActivitiesReport extends Component {
         title: "Skills Trainings Received",
         data: skills,
         rowHeight: 20,
-        useIcons: true,
-        icon: Icons.xCheckMark
+        useIcons: true
       }));
     }), React.createElement("style", null, studentRiskReportStyle));
   }
 
 }
-
-const ActivityTable = props => React.createElement("table", _extends({}, props, {
-  style: {
-    width: '100%',
-    textAlign: 'center',
-    borderSpacing: 0,
-    borderCollapse: 'collapse',
-    marginTop: 10,
-    pageBreakBefore: props.break ? 'always' : null
-  }
-}));
-
-const ActivityTableHeader = props => React.createElement("thead", {
-  style: {
-    display: 'flex',
-    flexDirection: 'row',
-    backgroundColor: '#D43425',
-    color: 'white',
-    fontSize: 12,
-    height: 30
-  }
-}, React.createElement("tr", null, React.createElement("td", {
-  style: {
-    fontSize: 16,
-    textAlign: 'left',
-    paddingLeft: 10
-  }
-}, props.title), props.terms.map((term, i) => React.createElement("td", {
-  key: i
-}, term.name))));
-
-const IEPData = props => {
-  const {
-    role
-  } = props;
-  const attended = !!role ? 'YES' : ' ';
-  const roleDisplay = role || ' ';
-  return React.createElement("td", {
-    style: {
-      fontSize: 8,
-      borderLeft: '1px solid #D43425'
-    }
-  }, React.createElement("div", null, attended), React.createElement("span", null, roleDisplay));
-};
-
-const IEPActivityTable = props => {
-  const {
-    terms,
-    students
-  } = props;
-  return React.createElement(ActivityTable, null, React.createElement(ActivityTableHeader, {
-    title: 'ATTENDED IEP MEETING',
-    terms: terms
-  }), React.createElement("tbody", {
-    style: {
-      borderTop: '10px solid white'
-    }
-  }, React.createElement("tr", {
-    style: {
-      backgroundColor: '#F4F4F4'
-    }
-  }, React.createElement("td", null), students.map((student, i) => {
-    const {
-      iepRoles
-    } = student;
-    return React.createElement(React.Fragment, {
-      key: i
-    }, iepRoles.map((role, idx) => {
-      return React.createElement(IEPData, {
-        key: `role_${idx}`,
-        role: role
-      });
-    }));
-  }))));
-};
-
-const GraduationPlanActivitiesTable = props => {
-  const {
-    terms,
-    students
-  } = props;
-  return React.createElement(ActivityTable, null, React.createElement(ActivityTableHeader, {
-    title: "CAREER DEVELOPMENT/GRADUATION PLAN",
-    terms: terms
-  }), React.createElement("tbody", {
-    style: {
-      borderTop: '10px solid white'
-    }
-  }, React.createElement("tr", {
-    style: {
-      backgroundColor: '#F4F4F4'
-    }
-  }, React.createElement("td", {
-    style: {
-      width: 510
-    }
-  }), students.map((student, i) => {
-    const {
-      graduationPlans
-    } = student;
-    return React.createElement(React.Fragment, {
-      key: i
-    }, graduationPlans.map((graduationPlan, idx) => {
-      return React.createElement("td", {
-        key: `plan_${idx}`,
-        style: {
-          fontSize: 8,
-          borderLeft: '1px solid #D43425',
-          width: 200
-        }
-      }, React.createElement("div", null, graduationPlan ? `YES` : ' '));
-    }));
-  }))));
-};
 
 module.exports = data => React.createElement(StudentActivitiesReport, {
   data: data

--- a/reportTemplates/styles/activityOverTimeTable.js
+++ b/reportTemplates/styles/activityOverTimeTable.js
@@ -1,18 +1,16 @@
-const riskIndicatorStyle = require('./riskIndicator');
-
 module.exports = `
-  .terms-table-row {
+ .activity-over-time-table-row {
     display: -webkit-flex;
     font-size: 11px;
     -webkit-justify-content: space-between;
     -webkit-align-items: center;
   }
 
-  .terms-table-row:nth-child(2n) {
+  .activity-over-time-table-row:nth-child(2n) {
     background: #F4F4F4;
   }
 
-  .terms-table-header {
+  .activity-over-time-table-header {
     min-height: 34px;
     background: #D43425;
     color: white;
@@ -20,30 +18,31 @@ module.exports = `
     font-family: Oswald;
   }
 
-  .terms-table-body {
+  .activity-over-time-table-body {
     height: 34px;
   }
 
-  .terms-table-header-label {
+  .activity-over-time-table-header-label {
     -webkit-flex: 1;
     text-align: center;
+    font-size: 8px;
   }
 
-  .terms-table-title {
+  .activity-over-time-table-title {
     text-transform: uppercase;
   }
 
-  .terms-table-title {
+  .activity-over-time-table-title {
     padding-left: 7px;
-    min-width: 130px;
+    min-width: 510px;
     box-sizing: border-box;
   }
 
-  .terms-table-label-container {
-    width: 130px;
+  .activity-over-time-table-label-container {
+    width: 510px;
   }
 
-  .terms-table-label-container {
+  .activity-over-time-table-label-container {
     display: -webkit-flex;
     font-size: 8px;
     font-weight: bold;
@@ -52,16 +51,7 @@ module.exports = `
     box-sizing: border-box;
   }
 
-  .terms-table-risk-label-container .terms-table-label {
-    min-width: 70%;
-  }
-
-  .terms-table-risk-label-container {
-    height: 100%;
-    -webkit-align-items: center;
-  }
-
-  .terms-table-value {
+  .activity-over-time-table-value {
     -webkit-flex: 1;
     border-left: 1px solid #D43425;
     height: 100%;
@@ -69,6 +59,4 @@ module.exports = `
     -webkit-justify-content: center;
     -webkit-align-items: center;
   }
-
-  ${riskIndicatorStyle}
 `;

--- a/reportTemplatesSrc/components/ActivityOverTimeTable.js
+++ b/reportTemplatesSrc/components/ActivityOverTimeTable.js
@@ -1,0 +1,56 @@
+const React = require('react');
+const activityOverTimeTable = require('../styles/activityOverTimeTable');
+
+function displayValue(value, defaultValue = 'N/A') {
+  if(value == null) return defaultValue;
+  return value;
+}
+
+const TermsHeader = ({ title, terms }) => (
+  <div className='activity-over-time-table-row activity-over-time-table-header'>
+    <div className='activity-over-time-table-title'>{title}</div>
+    <React.Fragment>
+      {terms && terms.map((term, i) =>
+        <div className='activity-over-time-table-header-label' key={i}>
+          <div>{term.name}</div>
+        </div>
+      )}
+    </React.Fragment>
+  </div>
+);
+
+const TermsRow = ({ entry, height }) => {
+  const {
+    label,
+    values,
+  } = entry;
+  return (
+    <div className='activity-over-time-table-row activity-over-time-table-body' style={{ height }}>
+      <div className='activity-over-time-table-label-container'>
+        <div className='activity-over-time-table-label'>
+          {label}
+        </div>
+      </div>
+      {values.map((value, i) => 
+        <div className='activity-over-time-table-value' key={i}>
+          {displayValue(value)}
+        </div>
+      )}
+    </div>
+  );
+};
+
+module.exports = function ActivityOverTimeTable({ rows, title, rowHeight, terms}) {
+
+  return (
+    <React.Fragment>
+      <div className='activity-over-time-table'>
+        <TermsHeader title={title} terms={terms} />
+        {rows.map((entry, i) =>
+          <TermsRow key={i} entry={entry}  eight={rowHeight} />
+        )}
+      </div>
+      <style>{activityOverTimeTable}</style>
+    </React.Fragment>
+  );
+};

--- a/reportTemplatesSrc/studentActivitiesReport.js
+++ b/reportTemplatesSrc/studentActivitiesReport.js
@@ -4,7 +4,7 @@ const MultiTermReportTitle = require('./components/MultiTermReportTitle');
 const TermsTable = require('./components/TermsTable');
 const StudentStatusBar = require('./components/StudentStatusBar');
 const studentRiskReportStyle = require('./styles/studentRiskReport');
-const Icons = require('./components/icons');
+const ActivityOverTimeTable = require('./components/ActivityOverTimeTable');
 
 class StudentActivitiesReport extends Component {
   render() {
@@ -20,6 +20,33 @@ class StudentActivitiesReport extends Component {
       activityTypeGroups,
     } = this.props.data;
 
+    const iepRows = students.map(student => {
+      const { iepRoles } = student;
+      const values = iepRoles.map((role, i) => {
+        const attended = !!role ? 'YES' : ' ';
+        const roleDisplay = role || ' ';
+        return (
+          <div key={`student_role_${i}`}>
+            <div>{attended}</div>
+            <div>{roleDisplay}</div>
+          </div>
+        );
+      });
+      return {
+        label: '',
+        values,
+      }
+    });
+
+    const gradPlanRows = students.map(student => {
+      const { graduationPlans } = student;
+      const values = graduationPlans.map(graduationPlan => (graduationPlan ? 'YES' : ' '));
+      return {
+        label: '',
+        values,
+      }
+    });
+
     return (
       <React.Fragment>
         <MultiTermReportTitle
@@ -32,28 +59,25 @@ class StudentActivitiesReport extends Component {
         />
         <StudentStatusBar student={studentInfo}/>
 
-        <IEPActivityTable terms={terms} students={students} />
-        <GraduationPlanActivitiesTable terms={terms} students={students} />
+        <ActivityOverTimeTable title='ATTENDED IEP MEETING' terms={terms} rows={iepRows } />
+        <ActivityOverTimeTable title='CAREER DEVELOPMENT / GRADUATION PLAN' terms={terms} rows={gradPlanRows } />
 
-        {activityTypeGroups.map((group, i) =>
-          <ActivityTable key={group.id} break={i === 1 || i === 3}>
-            <ActivityTableHeader title={group.name} terms={terms}></ActivityTableHeader>
-            <tbody style={{borderTop: '10px solid white'}}>
-              {group.activityTypes.map((type, i) =>
-                <tr key={type.id} style={{
-                  backgroundColor: i % 2 ? 'white' : '#F4F4F4'
-                }}>
-                  <td style={{ textAlign: 'left', fontSize: 10, paddingLeft: 10 }}>{type.name}</td>
-                  {terms.map(term =>
-                    <td key={term.id} style={{ fontSize: 8, borderLeft: '1px solid #D43425' }}>
-                      {term.student ? term.student.activities.filter(a => a.activityTypeId === type.id).length : 'N/A'}
-                    </td>  
-                  )}
-                </tr>  
-              )}
-            </tbody>
-          </ActivityTable>
-        )}
+        {activityTypeGroups.map((group, i) => {
+          const activityGroupRows = group.activityTypes.map((type) => {
+            const values = terms.map(term => (term.student ?
+              term.student.activities.filter(a => a.activityTypeId === type.id).length : 'N/A'));
+            const label = type.name;
+            return {
+              label, values,
+            }
+          });
+          return (
+            <React.Fragment key={group.id}>
+              {[0, 1, 3].includes(i) && <div style={{ pageBreakBefore: 'always' }} />}
+              <ActivityOverTimeTable title={group.name} terms={terms} rows={activityGroupRows} />
+            </React.Fragment>
+          );
+        })}        
         {students.map((student, i) => {
           const { riskFactors, studentNeeds, skills } = student;
           return (
@@ -61,7 +85,7 @@ class StudentActivitiesReport extends Component {
               <div style={{pageBreakBefore: 'always'}}/>
               <TermsTable title='Risk Factors' data={riskFactors} rowHeight={23}/>
               <TermsTable title='Areas where student might need support or intervention' data={studentNeeds} rowHeight={20} useIcons />
-              <TermsTable title='Skills Trainings Received' data={skills} rowHeight={20} useIcons icon={Icons.xCheckMark} />
+              <TermsTable title='Skills Trainings Received' data={skills} rowHeight={20} useIcons />
             </React.Fragment>
           );
         })}
@@ -69,112 +93,6 @@ class StudentActivitiesReport extends Component {
       </React.Fragment>
     );
   }
-}
-
-const ActivityTable = props => (
-  <table {...props} style={{
-    width: '100%',
-    textAlign: 'center',
-    borderSpacing: 0,
-    borderCollapse: 'collapse',
-    marginTop: 10,
-    pageBreakBefore: props.break ? 'always' : null,
-  }}/>
-);
-
-const ActivityTableHeader = props => (
-  <thead style={{
-    display: 'flex',
-    flexDirection: 'row',
-    backgroundColor: '#D43425',
-    color: 'white',
-    fontSize: 12,
-    height: 30,
-  }}>
-    <tr>
-      <td style={{ fontSize: 16, textAlign: 'left', paddingLeft: 10 }}>{props.title}</td>
-      {props.terms.map((term, i) =>
-        <td key={i}>{term.name}</td>
-      )}
-    </tr>
-  </thead>
-);
-
-
-const IEPData = props => {
-  const { role } = props;
-  const attended = !!role ? 'YES' : ' ';
-  const roleDisplay = role || ' ';
-  return (
-    <td style={{ 
-        fontSize: 8, 
-        borderLeft: '1px solid #D43425',
-        
-      }}>
-        <div>{attended}</div>
-        <span>{roleDisplay}</span>
-    </td>
-  );
-}
-
-const IEPActivityTable = props => {
-  const {terms, students} = props;
-
-  return (
-    <ActivityTable>
-      <ActivityTableHeader title={'ATTENDED IEP MEETING'} terms={terms} />
-      <tbody style={{ borderTop: '10px solid white' }}>
-        <tr style={{ 
-            backgroundColor: '#F4F4F4',
-        }}>
-          <td>{/* placeholder for layout */}</td>
-          {students.map((student, i) => {
-            const { iepRoles } = student;
-            return (
-              <React.Fragment key={i}>
-                {iepRoles.map((role, idx) => {
-                  return (
-                    <IEPData key={`role_${idx}`} role={role} />
-                  );
-                })
-                }
-              </React.Fragment>
-            );
-          })}
-        </tr>
-      </tbody>
-    </ActivityTable>
-  );
-}
-
-const GraduationPlanActivitiesTable = props => {
-  const {terms, students} = props;
-
-  return (
-    <ActivityTable>
-      <ActivityTableHeader title='CAREER DEVELOPMENT/GRADUATION PLAN' terms={terms} />
-      <tbody style={{ borderTop: '10px solid white' }}>
-        <tr style={{ backgroundColor: '#F4F4F4' }}>
-          <td style={{width: 510}}>{/* placeholder for layout */}</td>
-          {students.map((student, i) => {
-            const { graduationPlans } = student;
-            return (
-              <React.Fragment key={i}>
-                {graduationPlans.map((graduationPlan, idx) => {
-                  return (
-                    <td key={`plan_${idx}`} style={{ fontSize: 8, borderLeft: '1px solid #D43425', width: 200 }}>
-                      <div>{graduationPlan ? `YES` : ' '}</div>
-                    </td>
-                  );
-                })
-                }
-              </React.Fragment>
-            );
-          })}
-        </tr>
-      </tbody>
-    </ActivityTable>
-  );
 }
 
 module.exports = (data) => <StudentActivitiesReport data={data} />;

--- a/reportTemplatesSrc/styles/activityOverTimeTable.js
+++ b/reportTemplatesSrc/styles/activityOverTimeTable.js
@@ -1,18 +1,16 @@
-const riskIndicatorStyle = require('./riskIndicator');
-
 module.exports = `
-  .terms-table-row {
+ .activity-over-time-table-row {
     display: -webkit-flex;
     font-size: 11px;
     -webkit-justify-content: space-between;
     -webkit-align-items: center;
   }
 
-  .terms-table-row:nth-child(2n) {
+  .activity-over-time-table-row:nth-child(2n) {
     background: #F4F4F4;
   }
 
-  .terms-table-header {
+  .activity-over-time-table-header {
     min-height: 34px;
     background: #D43425;
     color: white;
@@ -20,30 +18,31 @@ module.exports = `
     font-family: Oswald;
   }
 
-  .terms-table-body {
+  .activity-over-time-table-body {
     height: 34px;
   }
 
-  .terms-table-header-label {
+  .activity-over-time-table-header-label {
     -webkit-flex: 1;
     text-align: center;
+    font-size: 8px;
   }
 
-  .terms-table-title {
+  .activity-over-time-table-title {
     text-transform: uppercase;
   }
 
-  .terms-table-title {
+  .activity-over-time-table-title {
     padding-left: 7px;
-    min-width: 130px;
+    min-width: 510px;
     box-sizing: border-box;
   }
 
-  .terms-table-label-container {
-    width: 130px;
+  .activity-over-time-table-label-container {
+    width: 510px;
   }
 
-  .terms-table-label-container {
+  .activity-over-time-table-label-container {
     display: -webkit-flex;
     font-size: 8px;
     font-weight: bold;
@@ -52,16 +51,7 @@ module.exports = `
     box-sizing: border-box;
   }
 
-  .terms-table-risk-label-container .terms-table-label {
-    min-width: 70%;
-  }
-
-  .terms-table-risk-label-container {
-    height: 100%;
-    -webkit-align-items: center;
-  }
-
-  .terms-table-value {
+  .activity-over-time-table-value {
     -webkit-flex: 1;
     border-left: 1px solid #D43425;
     height: 100%;
@@ -69,6 +59,4 @@ module.exports = `
     -webkit-justify-content: center;
     -webkit-align-items: center;
   }
-
-  ${riskIndicatorStyle}
 `;

--- a/reportTemplatesSrc/styles/termsTable.js
+++ b/reportTemplatesSrc/styles/termsTable.js
@@ -45,7 +45,7 @@ module.exports = `
 
   .terms-table-label-container {
     display: -webkit-flex;
-    font-size: 9px;
+    font-size: 8px;
     font-weight: bold;
     padding-left: 7px;
     padding-right: 7px;


### PR DESCRIPTION
Wasn't having much success jumping around the inline styles, so I extracted everything to its own file, switched to using css and styled it similar to the Risk Factors table. 

[student-over-time-report-2018-2019-T1-Chadd-Schulist.pdf](https://github.com/NTACT/transition-gradebook-server/files/3142710/student-over-time-report-2018-2019-T1-Chadd-Schulist.pdf)
