### PR TITLE
Adding Multiple Student Activity endpoint

### DIFF
--- a/routes/activities.router.js
+++ b/routes/activities.router.js
@@ -22,17 +22,9 @@ module.exports = context => {
       });
     })
 
-    .post('/activities/:studentId/:schoolYearId', auth(), async ctx => {
-      const studentId = +ctx.params.studentId;
-      const schoolYearId = +ctx.params.schoolYearId;
-      const fields = {
-        ...ctx.request.body,
-        studentId,
-        schoolYearId,
-      };
-
+    .post('/activities', auth(), async ctx => {
       success(ctx, {
-        activity: await activityController.createActivity(fields),
+        activities: await activityController.createActivity(ctx.request.body),
       });
     })
 

--- a/tests/activities.test.js
+++ b/tests/activities.test.js
@@ -11,19 +11,36 @@ describe('Activities', () => {
     expect(activities).toBeTruthy();
   });
 
-  rapidTest(`Users should be able to POST new student activities through /activities/:studentId/:schoolYearId`, async rapid => {
-    const response = await rapid.axios.post('/api/activities/1/1', {
+  rapidTest(`Users should be able to POST new student activities through /activities`, async rapid => {
+    const response = await rapid.axios.post('/api/activities', {
+      studentIds: [1],
+      schoolYearId: 1,
       activityTypeId: 1,
       notes: 'Some notes!',
       frequency: 'Daily',
       events: [
-        {eventTime: new Date()},
-        {eventTime: new Date()},
-        {eventTime: new Date()},
+        { eventTime: new Date() },
+        { eventTime: new Date() },
+        { eventTime: new Date() },
       ]
     }, await rapid.auth());
     await shouldSucceed(response);
   });
+
+  rapidTest('Users should be able to POST multiple student IDs to /activities to create multiple activities.', async rapid => {
+    const response = await rapid.axios.post('/api/activities', {
+      studentIds: [1, 2, 3],
+      schoolYearId: 1,
+      activityTypeId: 1,
+      notes: 'Some notes, given to multiple students!',
+      frequency: 'Daily',
+      events: [
+        { eventTime: new Date() }
+      ]
+    }, await rapid.auth());
+    await shouldSucceed(response);
+    expect(response.data.activities.length).toEqual(3)
+  })
 
   rapidTest('Users should be able to POST student activity changes through /activities/:studentId/:schoolYearId/:activityId', async rapid => {
     // Create activity
@@ -32,9 +49,9 @@ describe('Activities', () => {
       notes: 'Some notes!',
       frequency: 'Daily',
       events: [
-        {eventTime: new Date()},
-        {eventTime: new Date()},
-        {eventTime: new Date()},
+        { eventTime: new Date() },
+        { eventTime: new Date() },
+        { eventTime: new Date() },
       ]
     }, await rapid.auth());
 
@@ -44,7 +61,7 @@ describe('Activities', () => {
       notes: 'Edited notes',
       frequency: 'Daily',
       events: [
-        {eventTime: new Date()},
+        { eventTime: new Date() },
       ]
     }, await rapid.auth());
 
@@ -66,7 +83,7 @@ describe('Activities', () => {
 
   rapidTest(`Non-users shouldn't be able to access activity endpoints`, async rapid => {
     const getResponse = await rapid.axios.get('/api/activities/1/1');
-    const createResponse = await rapid.axios.post('/api/activities/1/1', {
+    const createResponse = await rapid.axios.post('/api/activities', {
       activityTypeId: 1,
       notes: 'Some notes!',
     });


### PR DESCRIPTION
Edits `/api/activities` endpoint to accept and array of student IDs and all activity form fields, and creates multiple student activity records. Adds tests for this new endpoint behavior.