### PR TITLE
Remove hard-coded heroku template URL from the 'Deploy to Heroku' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Transition Gradebook Server
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/NTACT/transition-gradebook-server)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
-For more information regarding this project, please contact [NTACT](https://transitionta.org/). 
+For more information regarding this project, please contact [NTACT](https://transitionta.org/).


### PR DESCRIPTION
This way the forked repo will be used instead of the NTACT repo if the user forks before pressing the button.
https://devcenter.heroku.com/articles/heroku-button#using-an-implicit-template